### PR TITLE
Add smoke e2e test asserting waveform appears after synthesizing song

### DIFF
--- a/web-e2e/src/test/kotlin/it/krzeminski/fsynth/SmokeTest.kt
+++ b/web-e2e/src/test/kotlin/it/krzeminski/fsynth/SmokeTest.kt
@@ -6,6 +6,7 @@ import io.github.bonigarcia.wdm.WebDriverManager
 import java.io.File
 import java.net.InetSocketAddress
 import java.nio.file.Files
+import java.time.Duration
 import org.junit.AfterClass
 import org.junit.Assert.assertTrue
 import org.junit.BeforeClass
@@ -13,6 +14,8 @@ import org.junit.Test
 import org.openqa.selenium.By
 import org.openqa.selenium.chrome.ChromeDriver
 import org.openqa.selenium.chrome.ChromeOptions
+import org.openqa.selenium.support.ui.ExpectedConditions
+import org.openqa.selenium.support.ui.WebDriverWait
 
 class SmokeTest {
     companion object {
@@ -67,5 +70,22 @@ class SmokeTest {
         assertTrue("Page should contain app title", bodyText.contains("fsynth"))
         assertTrue("Page should contain at least one song name", bodyText.contains("Simple demo song"))
         assertTrue("Page should contain playback customization section", bodyText.contains("Playback customization"))
+    }
+
+    @Test
+    fun waveformIsDisplayedAfterSynthesizingSimpleDemoSong() {
+        driver.get("http://localhost:$PORT/index.html")
+
+        val playButton = driver.findElement(
+            By.xpath("//*[contains(text(), 'Simple demo song')]/ancestor::li//button")
+        )
+        playButton.click()
+
+        val wait = WebDriverWait(driver, Duration.ofSeconds(15))
+        val waveform = wait.until(
+            ExpectedConditions.visibilityOfElementLocated(By.id("waveform"))
+        )
+
+        assertTrue("Waveform should be visible after synthesis", waveform.isDisplayed)
     }
 }


### PR DESCRIPTION
Extends the existing Selenium e2e test suite with a new test that:
1. Clicks the play button for "Simple demo song"
2. Waits for the waveform component to appear (synthesis may take a few seconds)
3. Asserts the waveform is visible